### PR TITLE
updated POSTFIELDS character separator

### DIFF
--- a/src/ChatbotAPI/APIClient.php
+++ b/src/ChatbotAPI/APIClient.php
@@ -101,7 +101,7 @@ class APIClient
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_POST => ($method == "POST") ? 1 : 0,
-            CURLOPT_POSTFIELDS => implode(",", $params),
+            CURLOPT_POSTFIELDS => implode("&", $params),
             CURLOPT_HTTPHEADER => $headers,
         );
 


### PR DESCRIPTION
The character that separate values in implode should be "&" instead of ","